### PR TITLE
[2021-03-31]용석:JPA를 이용한 조회 API[#1]:Entity를 그대로 반환하는 API

### DIFF
--- a/src/main/java/io/exercise/shop/controller/OrderQueryIssueController.java
+++ b/src/main/java/io/exercise/shop/controller/OrderQueryIssueController.java
@@ -1,6 +1,7 @@
 package io.exercise.shop.controller;
 
 import io.exercise.shop.domain.entity.Order;
+import io.exercise.shop.domain.entity.OrderItem;
 import io.exercise.shop.service.query.OrderQueryIssueSolutionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,6 +33,10 @@ public class OrderQueryIssueController {
         for (Order order : allOrder) {
             order.getMember().getMemberName();
             order.getDelivery().getDeliveryStatus();
+            for (OrderItem orderItem : order.getOrderItemList()) {
+                orderItem.getItem().getItemName();
+                orderItem.getOrderPrice();
+            }
         }
         return allOrder;
     }

--- a/src/main/java/io/exercise/shop/controller/OrderQueryIssueController.java
+++ b/src/main/java/io/exercise/shop/controller/OrderQueryIssueController.java
@@ -1,0 +1,38 @@
+package io.exercise.shop.controller;
+
+import io.exercise.shop.domain.entity.Order;
+import io.exercise.shop.service.query.OrderQueryIssueSolutionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RestController
+@RequestMapping(
+        value = "/api/order",
+        consumes = APPLICATION_JSON_VALUE,
+        produces = APPLICATION_JSON_VALUE
+)
+@RequiredArgsConstructor
+public class OrderQueryIssueController {
+
+    private final OrderQueryIssueSolutionService orderQueryIssueSolutionService;
+
+    /**
+     * Entity를 그대로 반환하는 API
+     * @return
+     */
+    @GetMapping(value = "/v1")
+    public List<Order> getOrderListV1(){
+        List<Order> allOrder = orderQueryIssueSolutionService.findAllOrder();
+        for (Order order : allOrder) {
+            order.getMember().getMemberName();
+            order.getDelivery().getDeliveryStatus();
+        }
+        return allOrder;
+    }
+}

--- a/src/main/java/io/exercise/shop/domain/entity/Delivery.java
+++ b/src/main/java/io/exercise/shop/domain/entity/Delivery.java
@@ -1,6 +1,10 @@
 package io.exercise.shop.domain.entity;
 
-import lombok.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
@@ -19,6 +23,13 @@ public class Delivery {
     @Column(name = "delivery_no")
     private Long deliveryNo;
 
+    /**
+     * @JsonIgnore를 명시한 이유
+     * 양방향 연관관계를 가진 Entity를 직접 반환하는 경우
+     * 객체 직렬화 시 상호 참조로 인해 발생하는 무한 루프를 방지 하기 위해
+     * 한쪽에 @JsonIgnore를 명시하여 직렬화 과정에서 발생하는 무한루프를 방지
+     */
+    @JsonIgnore
     @OneToOne(mappedBy = "delivery", fetch = LAZY)
     private Order order;
 

--- a/src/main/java/io/exercise/shop/domain/entity/Member.java
+++ b/src/main/java/io/exercise/shop/domain/entity/Member.java
@@ -1,6 +1,10 @@
 package io.exercise.shop.domain.entity;
 
-import lombok.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -27,6 +31,13 @@ public class Member {
     @Embedded
     private Address address;
 
+    /**
+     * @JsonIgnore를 명시한 이유
+     * 양방향 연관관계를 가진 Entity를 직접 반환하는 경우
+     * 객체 직렬화 시 상호 참조로 인해 발생하는 무한 루프를 방지 하기 위해
+     * 한쪽에 @JsonIgnore를 명시하여 직렬화 과정에서 발생하는 무한루프를 방지
+     */
+    @JsonIgnore
     @OneToMany(mappedBy = "member", fetch = LAZY)
     private List<Order> orderList = new ArrayList<>();
 

--- a/src/main/java/io/exercise/shop/domain/entity/OrderItem.java
+++ b/src/main/java/io/exercise/shop/domain/entity/OrderItem.java
@@ -1,5 +1,6 @@
 package io.exercise.shop.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.exercise.shop.domain.entity.item.Item;
 import lombok.*;
 
@@ -22,6 +23,13 @@ public class OrderItem {
     @Column(name = "order_item_no")
     private Long orderItemNo;
 
+    /**
+     * @JsonIgnore를 명시한 이유
+     * 양방향 연관관계를 가진 Entity를 직접 반환하는 경우
+     * 객체 직렬화 시 상호 참조로 인해 발생하는 무한 루프를 방지 하기 위해
+     * 한쪽에 @JsonIgnore를 명시하여 직렬화 과정에서 발생하는 무한루프를 방지
+     */
+    @JsonIgnore
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "order_no")
     private Order order;

--- a/src/main/java/io/exercise/shop/domain/entity/item/Category.java
+++ b/src/main/java/io/exercise/shop/domain/entity/item/Category.java
@@ -1,5 +1,6 @@
 package io.exercise.shop.domain.entity.item;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 
 import javax.persistence.*;
@@ -30,6 +31,13 @@ public class Category {
     )
     private List<Item> itemList = new ArrayList<>();
 
+    /**
+     * @JsonIgnore를 명시한 이유
+     * 양방향 연관관계를 가진 Entity를 직접 반환하는 경우
+     * 객체 직렬화 시 상호 참조로 인해 발생하는 무한 루프를 방지 하기 위해
+     * 한쪽에 @JsonIgnore를 명시하여 직렬화 과정에서 발생하는 무한루프를 방지
+     */
+    @JsonIgnore
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "parent_no")
     private Category parentCategory;

--- a/src/main/java/io/exercise/shop/repository/query/OrderQueryIssueSolutionRepository.java
+++ b/src/main/java/io/exercise/shop/repository/query/OrderQueryIssueSolutionRepository.java
@@ -1,0 +1,20 @@
+package io.exercise.shop.repository.query;
+
+import io.exercise.shop.domain.entity.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderQueryIssueSolutionRepository {
+
+    private final EntityManager entityManager;
+
+    public List<Order> findAll(){
+        return entityManager.createQuery("select o from Order as o")
+                .getResultList();
+    }
+}

--- a/src/main/java/io/exercise/shop/service/query/OrderQueryIssueSolutionService.java
+++ b/src/main/java/io/exercise/shop/service/query/OrderQueryIssueSolutionService.java
@@ -1,0 +1,21 @@
+package io.exercise.shop.service.query;
+
+import io.exercise.shop.domain.entity.Order;
+import io.exercise.shop.repository.query.OrderQueryIssueSolutionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderQueryIssueSolutionService {
+
+    private final OrderQueryIssueSolutionRepository orderQueryIssueSolutionRepository;
+
+    public List<Order> findAllOrder(){
+        return orderQueryIssueSolutionRepository.findAll();
+    }
+}

--- a/src/test/java/io/exercise/shop/controller/OrderQueryIssueControllerTest.java
+++ b/src/test/java/io/exercise/shop/controller/OrderQueryIssueControllerTest.java
@@ -58,8 +58,35 @@ class OrderQueryIssueControllerTest {
         for (int i = 0; i < memberList.size(); i++) {
             orderService.saveOrder(memberList.get(i).getMemberNo(), itemList.get(i).getItemNo(), (i+1));
         }
+        entityManager.flush();
+        entityManager.clear();
     }
 
+
+    /**
+     * API에서 Entity를 직접 반환하는 경우 발생하는 3가지 이슈
+     *  - 이슈 1 : 반환하는 Entity가 단방향 연관관계를 가지는 경우
+     *    - 응답 반환 시 객체를 직렬화 하는 Jackson 라이브러리가
+     *      반환 Entity와 연관관계를 가지는 초기화 되지 않은 Entity의
+     *      프록시 객체를 직렬화 하는 과정에서 오류가 발생
+     *   - 해결 :
+     *     1. 초기화 되지 않은 프록시 객체를 LazyLoading을 이용하여 초기화 하여 직렬화 대상에 포함.
+     *     2. @JsonIgnore를 이용하여 초기화 되지 않은 프록시 객체를 직렬화 대상에서 제외.
+     *
+     *  - 이슈 2 : 반환하는 Entity가 양방향 연관관계를 가지는 경우
+     *    - 응답 반환 시 객체를 반환하기 위해 직렬화 하는 과정에서
+     *      양방향 연관관계를 가진 Entity의 상호 참조로 인해 무한 루프
+     *      발생 으로 인한 StackOverFlow 발생
+     *   - 해결 : @JsonIgnore를 이용하여 직렬화 시 한쪽의 연관관계를 끊어 무한루프를 제거
+     *
+     *   - 이슈 3 : Entity 수정으로 인해 API Spec이 변경 되는 경우
+     *    - 서비스를 운영하면서 발생하는 여러 수정 사항들로 인하여 Entity가 수정될 경우
+     *      API Spec이 변경되며, 해당 API 사용 하는 여러 Client측 에서 장애 발생
+     *
+     *  - 결론 : 조회된 Entity의 데이터를 이용하여 필요한 DataSet이 구성된 DTO로
+     *  변환 후 반환함으로써 Entity를 직접 반환 시 발생하는 이슈를 사전에 방지
+     * @throws Exception
+     */
     @Test
     @DisplayName("V1:Entity 직접 반환으로 인한 이슈")
     public void getOrderListV1() throws Exception {

--- a/src/test/java/io/exercise/shop/controller/OrderQueryIssueControllerTest.java
+++ b/src/test/java/io/exercise/shop/controller/OrderQueryIssueControllerTest.java
@@ -1,0 +1,80 @@
+package io.exercise.shop.controller;
+
+import io.exercise.shop.domain.entity.Member;
+import io.exercise.shop.domain.entity.item.Item;
+import io.exercise.shop.generator.ItemGenerator;
+import io.exercise.shop.generator.MemberGenerator;
+import io.exercise.shop.service.OrderService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@AutoConfigureMockMvc
+@Transactional
+@DisplayName("API:OrderQueryIssueSolution")
+class OrderQueryIssueControllerTest {
+
+    @Autowired OrderService orderService;
+    @Autowired EntityManager entityManager;
+    @Autowired MockMvc mockMvc;
+
+    /** GenericType saveAll */
+    private <T> void saveAll(List<T> paramList){
+        for (T param : paramList) {
+            entityManager.persist(param);
+        }
+        entityManager.flush();
+    }
+
+    /**
+     * 회원 생성 & 상품 생성
+     * 주문 생성
+     */
+    @BeforeEach
+    @DisplayName("Test 수행에 필요한 주문 정보 생성")
+    public void setUp(){
+        List<Member> memberList = new MemberGenerator().generateMemberList();
+        this.saveAll(memberList);
+
+        List<Item> itemList = new ItemGenerator().generateItemList();
+        this.saveAll(itemList);
+
+        for (int i = 0; i < memberList.size(); i++) {
+            orderService.saveOrder(memberList.get(i).getMemberNo(), itemList.get(i).getItemNo(), (i+1));
+        }
+    }
+
+    @Test
+    @DisplayName("V1:Entity 직접 반환으로 인한 이슈")
+    public void getOrderListV1() throws Exception {
+        // Given
+        String urlTemplate = "/api/order/v1";
+
+        // When
+        ResultActions resultActions = this.mockMvc.perform(get(urlTemplate)
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+        );
+
+        // Then
+        resultActions.andDo(print())
+                .andExpect(status().isOk())
+                ;
+    }
+}

--- a/src/test/java/io/exercise/shop/service/query/OrderQueryIssueSolutionServiceTest.java
+++ b/src/test/java/io/exercise/shop/service/query/OrderQueryIssueSolutionServiceTest.java
@@ -1,0 +1,71 @@
+package io.exercise.shop.service.query;
+
+import io.exercise.shop.domain.entity.Member;
+import io.exercise.shop.domain.entity.Order;
+import io.exercise.shop.domain.entity.item.Item;
+import io.exercise.shop.generator.ItemGenerator;
+import io.exercise.shop.generator.MemberGenerator;
+import io.exercise.shop.service.OrderService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@DisplayName("Service:OrderQueryIssueService")
+@Transactional
+class OrderQueryIssueSolutionServiceTest {
+
+    @Autowired
+    OrderQueryIssueSolutionService orderQueryIssueSolutionService;
+
+    @Autowired
+    OrderService orderService;
+
+    @Autowired
+    EntityManager entityManager;
+
+    /** GenericType saveAll */
+    private <T> void saveAll(List<T> paramList){
+        for (T param : paramList) {
+            entityManager.persist(param);
+        }
+        entityManager.flush();
+    }
+
+    /**
+     * 회원 생성 & 상품 생성
+     * 주문 생성
+     */
+    @BeforeEach
+    @DisplayName("Test 수행에 필요한 주문 정보 생성")
+    public void setUp(){
+        List<Member> memberList = new MemberGenerator().generateMemberList();
+        this.saveAll(memberList);
+
+        List<Item> itemList = new ItemGenerator().generateItemList();
+        this.saveAll(itemList);
+
+        for (int i = 0; i < memberList.size(); i++) {
+            orderService.saveOrder(memberList.get(i).getMemberNo(), itemList.get(i).getItemNo(), (i+1));
+        }
+    }
+
+    @Test
+    @DisplayName("newTest")
+    public void newTest() throws Exception {
+        // Given
+
+        // When
+        List<Order> allOrder = orderQueryIssueSolutionService.findAllOrder();
+
+        // Then
+    }
+}


### PR DESCRIPTION
 - API에서 Entity를 직접 반환하는 경우 발생하는 3가지 이슈 확인 및 해결
    - 이슈 1 : 반환하는 Entity가 단방향 연관관계를 가지는 경우
       - 응답 반환 시 객체를 직렬화 하는 Jackson 라이브러리가 반환 Entity와 연관관계를 가지는 초기화 되지 않은 Entity의 프록시 객체를 직렬화 하는 과정에서 오류가 발생
    - 해결 : LazyLoading을 이용하여 초기화 되지 않은 프록시 객체를 초기화 후 직렬화 대상에 포함

    - 이슈 2 : 반환하는 Entity가 양방향 연관관계를 가지는 경우
       - 응답 반환 시 객체를 반환하기 위해 직렬화 하는 과정에서 양방향 연관관계를 가진 Entity의 상호 참조로 인해 무한 루프발생 으로 인한 StackOverFlow 발생
    - 해결 : @JsonIgnore를 이용하여 직렬화 시 한쪽의 연관관계를 끊어 무한루프를 제거

    - 이슈 3 : Entity 수정으로 인해 API Spec이 변경 되는 경우
       - 서비스를 운영하면서 발생하는 여러 수정 사항들로 인하여 Entity가 수정될 경우 API Spec이 변경되며, 해당 API 사용 하는 여러 Client측에서 장애 발생

 - 결론 : 조회된 Entity의 데이터를 이용하여 필요한 DataSet이 구성된 DTO로 변환 후 반환함으로써 Entity를 직접 반환 시 발생하는 이슈를 사전에 방지