### PR TITLE
[2021-04-01]용석: JPA를 이용한 조회 쿼리 최적화

### DIFF
--- a/src/main/java/io/exercise/shop/controller/OrderQueryIssueController.java
+++ b/src/main/java/io/exercise/shop/controller/OrderQueryIssueController.java
@@ -1,7 +1,6 @@
 package io.exercise.shop.controller;
 
 import io.exercise.shop.domain.entity.Order;
-import io.exercise.shop.domain.entity.OrderItem;
 import io.exercise.shop.service.query.OrderQueryIssueSolutionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,15 +28,6 @@ public class OrderQueryIssueController {
      */
     @GetMapping(value = "/v1")
     public List<Order> getOrderListV1(){
-        List<Order> allOrder = orderQueryIssueSolutionService.findAllOrder();
-        for (Order order : allOrder) {
-            order.getMember().getMemberName();
-            order.getDelivery().getDeliveryStatus();
-            for (OrderItem orderItem : order.getOrderItemList()) {
-                orderItem.getItem().getItemName();
-                orderItem.getOrderPrice();
-            }
-        }
-        return allOrder;
+        return orderQueryIssueSolutionService.findAllOrder();
     }
 }

--- a/src/main/java/io/exercise/shop/controller/OrderQueryIssueController.java
+++ b/src/main/java/io/exercise/shop/controller/OrderQueryIssueController.java
@@ -1,5 +1,6 @@
 package io.exercise.shop.controller;
 
+import io.exercise.shop.domain.dto.response.OrderDtoWrap;
 import io.exercise.shop.domain.entity.Order;
 import io.exercise.shop.service.query.OrderQueryIssueSolutionService;
 import lombok.RequiredArgsConstructor;
@@ -30,4 +31,15 @@ public class OrderQueryIssueController {
     public List<Order> getOrderListV1(){
         return orderQueryIssueSolutionService.findAllOrder();
     }
+
+    /**
+     * N:1, 1:1의 관계를 fetch join으로,
+     * 1:N의 관계는 default_batch_fetch_size 설정을 이용하여 쿼리 최적화
+     * @return
+     */
+    @GetMapping(value = "/v2")
+    public OrderDtoWrap getOrderListV2(){
+        return orderQueryIssueSolutionService.findAllOrderAndMemberAndDelivery();
+    }
+
 }

--- a/src/main/java/io/exercise/shop/domain/dto/response/OrderDto.java
+++ b/src/main/java/io/exercise/shop/domain/dto/response/OrderDto.java
@@ -1,0 +1,39 @@
+package io.exercise.shop.domain.dto.response;
+
+import io.exercise.shop.domain.entity.Address;
+import io.exercise.shop.domain.entity.Order;
+import io.exercise.shop.domain.entity.OrderStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/01 7:26 오후
+ * @Content : 조회 Entity로부터 데이터를 설정하여 반환하기 위한 객체
+ */
+@Getter @Setter
+public class OrderDto {
+
+    private Long orderId;
+    private String name;
+    private LocalDateTime orderDate; //주문시간
+    private OrderStatus orderStatus;
+    private Address address;
+    private List<OrderItemDto> orderItems;
+
+    public OrderDto(Order order) {
+        orderId = order.getOrderNo();
+        name = order.getMember().getMemberName();
+        orderDate = order.getOrderDate();
+        orderStatus = order.getOrderStatus();
+        address = order.getDelivery().getAddress();
+        orderItems = order.getOrderItemList().stream()
+                .map(orderItem -> new OrderItemDto(orderItem))
+                .collect(toList());
+    }
+}

--- a/src/main/java/io/exercise/shop/domain/dto/response/OrderDtoWrap.java
+++ b/src/main/java/io/exercise/shop/domain/dto/response/OrderDtoWrap.java
@@ -1,0 +1,19 @@
+package io.exercise.shop.domain.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/01 7:26 오후
+ * @Content : API 반환 객체
+ */
+@Getter @Setter
+public class OrderDtoWrap {
+
+    @JsonProperty(value = "orderList")
+    List<OrderDto> orderDtoList;
+}

--- a/src/main/java/io/exercise/shop/domain/dto/response/OrderItemDto.java
+++ b/src/main/java/io/exercise/shop/domain/dto/response/OrderItemDto.java
@@ -1,0 +1,24 @@
+package io.exercise.shop.domain.dto.response;
+
+import io.exercise.shop.domain.entity.OrderItem;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/01 7:27 오후
+ * @Content : 조회 Entity로부터 데이터를 설정하여 반환하기 위한 객체
+ */
+@Getter @Setter
+public class OrderItemDto {
+
+    private String itemName;
+    private long orderPrice;
+    private int orderCount;
+
+    public OrderItemDto(OrderItem orderItem) {
+        itemName = orderItem.getItem().getItemName();
+        orderPrice = orderItem.getOrderPrice();
+        orderCount = orderItem.getOrderCount();
+    }
+}

--- a/src/main/java/io/exercise/shop/repository/query/OrderQueryIssueSolutionRepository.java
+++ b/src/main/java/io/exercise/shop/repository/query/OrderQueryIssueSolutionRepository.java
@@ -17,4 +17,15 @@ public class OrderQueryIssueSolutionRepository {
         return entityManager.createQuery("select o from Order as o")
                 .getResultList();
     }
+
+    /**
+     * Entity 조회 시 N:1, 1:1의 관계를 FETCH JOIN으로 조회
+     * @return
+     */
+    public List<Order> findByFetchJoin(){
+        return entityManager.createQuery("select o from Order as o" +
+                " join fetch o.member as m" +
+                " join fetch o.delivery as d")
+                .getResultList();
+    }
 }

--- a/src/main/java/io/exercise/shop/service/query/OrderQueryIssueSolutionService.java
+++ b/src/main/java/io/exercise/shop/service/query/OrderQueryIssueSolutionService.java
@@ -1,5 +1,7 @@
 package io.exercise.shop.service.query;
 
+import io.exercise.shop.domain.dto.response.OrderDto;
+import io.exercise.shop.domain.dto.response.OrderDtoWrap;
 import io.exercise.shop.domain.entity.Order;
 import io.exercise.shop.repository.query.OrderQueryIssueSolutionRepository;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +9,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 @Service
 @Transactional(readOnly = true)
@@ -17,5 +21,24 @@ public class OrderQueryIssueSolutionService {
 
     public List<Order> findAllOrder(){
         return orderQueryIssueSolutionRepository.findAll();
+    }
+
+    /**
+     * OSIV OFF시 트랜잭션은 Service 계층까지만 존재하므로
+     * 해당 계층에서 1:N 관계의 Entity를 LazyLoading하여 응답 객체로 변환
+     * @return
+     */
+    public OrderDtoWrap findAllOrderAndMemberAndDelivery(){
+
+        List<Order> orderList = orderQueryIssueSolutionRepository.findByFetchJoin();
+
+        List<OrderDto> orderDtoList = orderList.stream()
+                .map(o -> new OrderDto(o))
+                .collect(toList());
+
+        OrderDtoWrap orderDtoWrap = new OrderDtoWrap();
+        orderDtoWrap.setOrderDtoList(orderDtoList);
+
+        return orderDtoWrap;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop # create auto ddl script 옵션 create-drop : application 기동 시점에 Entity를 기준으로 Table Create 후 Application 종료 시점에 Drop
+    properties:
+      hibernate:
+        default_batch_fetch_size: 1000
 #    properties:
 #      hibernate:
 #        show_sql: true

--- a/src/test/java/io/exercise/shop/controller/OrderQueryIssueControllerTest.java
+++ b/src/test/java/io/exercise/shop/controller/OrderQueryIssueControllerTest.java
@@ -6,6 +6,7 @@ import io.exercise.shop.generator.ItemGenerator;
 import io.exercise.shop.generator.MemberGenerator;
 import io.exercise.shop.service.OrderService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -95,6 +96,7 @@ class OrderQueryIssueControllerTest {
      */
     @Test
     @DisplayName("V1:Entity 직접 반환으로 인한 이슈")
+    @Disabled
     public void getOrderListV1() throws Exception {
         // Given
         String urlTemplate = "/api/order/v1";
@@ -109,5 +111,29 @@ class OrderQueryIssueControllerTest {
         resultActions.andDo(print())
                 .andExpect(status().isOk())
                 ;
+    }
+
+    /**
+     * 1:1, N:1의 관계를 JOIN FETCH로 조회 후,
+     * 1:N 관계는 default_batch_fetch_size옵션을 적용하여
+     * LazyLoading시점에 IN절로 조회 하여 실행 쿼리 수 최적화
+     * @throws Exception
+     */
+    @Test
+    @DisplayName("V2:Entity를 DTO로 변환하여 반환")
+    public void getOrderListV2() throws Exception {
+        // Given
+        String urlTemplate = "/api/order/v2";
+
+        // When
+        ResultActions resultActions = this.mockMvc.perform(get(urlTemplate)
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+        );
+
+        // Then
+        resultActions.andDo(print())
+                .andExpect(status().isOk())
+        ;
     }
 }


### PR DESCRIPTION
 - Entity 직접변환 시 발생하는 여러 이슈 해결을 위해 DTO로 변환 후 반환
 - 응답에 필요한 Entity 조회 시 N:1, 1:1 관계를 'JOIN FETCH'로 조회
 - 1:N의 관계를 default_batch_fetch_size 설정을 통해 DTO 변환 시점에 LazyLoading을 이용하여 IN절 쿼리로 조회
 - 불필요 코드 삭제